### PR TITLE
profile: add a document presenting Bump on the Github “bump-sh” profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,22 @@
+<p align="center">
+  <img width="20%" src="https://bump.sh/icon-default-large.png" />
+</p>
+
+<p align="center">
+  <a href="https://help.bump.sh/">Help</a> |
+  <a href="https://bump.sh/users/sign_up">Sign up</a>
+</p>
+
+[![Bump.sh](https://img.shields.io/badge/Bump.sh-https://bump.sh-025fd7.svg)](https://bump.sh)
+[![Twitter](https://img.shields.io/badge/Twitter-@bump_hq-9cf.svg)](https://twitter.com/bump_hq)
+[![LinkedIN](https://img.shields.io/badge/LinkedIn-@bump_sh-lightgray.svg)](https://www.linkedin.com/company/bump-sh)
+
+Bump allows you to easily **generate your API documentation and API changelog**.
+
+From an [OpenAPI](https://spec.openapis.org/oas/latest.html) or [AsyncAPI](https://www.asyncapi.com/) specification, you can deploy your **API documentation in a couple of minutes**. You can customize your documentation UI (title, colors, menu), protect it with a password, and customize its URL with your own domain.
+
+Share a link to your documentation with your API consumers and help them to never miss an API change again. They will have the possibility to **track API structural changes** if they subscribe by email. Once a week, subscribers will receive a changelog digest of your documentation if your API has changed. Curious? Here is the API [documentation changelog](https://developers.bump.sh/changes) of our own API.
+
+To make the most out of Bump, we suggest integrating our tool in your development process. We offer a [Command Line Interface](https://github.com/bump-sh/cli/blob/master/package.json)) and [Continuous Integration](https://help.bump.sh/continuous-integration) examples to let you: view API diff during code review thanks to our [Github Action](https://github.com/bump-sh/github-action), Bump will automatically **comment your pull requests with changes digest**, then once merged we will **deploy your changes** directly to your documentation page.
+
+If you work in a multiple services environment and have many different APIs, we got you covered. You can organize and mix your OpenAPI and AsyncAPI based documentations in a developer Hub. You will thus have **all of your APIs listed in one place**. Check our [demo “Train company” hub](https://demo.bump.sh/) for a live example.


### PR DESCRIPTION
Github allows to customize the public organisation
profile page (https://github.com/bump-sh) by defining a
profile/README.md file in the community repo.

Let's use it!